### PR TITLE
Update memos.json

### DIFF
--- a/memos.json
+++ b/memos.json
@@ -404,6 +404,12 @@
     "link": "https://memos.snbing.com",
     "creatorId": "1",
     "avatar": "https://gravatar.memobbs.app/avatar/6dbd4ced83699b94b2c2c59c33aaee40?size=80"
+  },{
+    "creatorName": "CuB3y0nd",
+    "website": "https://www.cubeyond.net",
+    "link": "https://memos.cubeyond.net",
+    "creatorId": "1",
+    "avatar": "https://www.cubeyond.net/_next/image?url=%2Fstatic%2Fimages%2Favatar.png&w=256&q=75"
   }
 
 ]


### PR DESCRIPTION
我搭的这个 memos 是 IPv6 网站，没有 IPv6 不一定可以访问，所以我之前提交的地址是 http://memos.cubeyond.net:5230。虽然不知道为什么这样就可以在没有 IPv6 的情况下访问只支持 IPv6 的站点